### PR TITLE
Santactl v0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,43 +2,255 @@
 
 This is a proof-of-concept clone of Google's [Santa](https://github.com/google/santa), a binary authorization system for macOS. The design is similar in the use of both a kernel module and userland daemon component to make policy decisions based on the SHA256 hash of the target file being executed.
 
-At a high level, the sequence of events on each execution is as follows:
+```sh
+# show the current rules
+$ santactl rule show
+{
+  "a92d9b7533984599bb263f703b5968db9a07f49aa6bb416faa535cd781debcbb": "Block",
+  "f5d5379e0ec9b97813f546bd12029657b7c51135fcd8439bca9333ab1dfdf557": "Allow"
+}
 
-1. The kernel module intercepts calls to the function `finalize_exec()` using a kprobe pre-handler
-    - The module gets the PID of the process that is executing the target binary
-2. The kernel module sends a message containing the target PID to the daemon over a generic netlink socket
-    - A kernel completion is initialized and waits for a response from the daemon without blocking (but still holding execution of the target binary)
-3. The daemon processes incoming messages from the kernel and parses the PID from the message
-4. The daemon calculates the SHA256 sum of the target binary by reading from `/proc/<pid>/exe`
-    - The daemon checks whether the hash is present on the blocklist or allowlist
-    - If on the allowlist, execution is allowed
-    - If on the blocklist, execution is blocked
-    - If neither, the file is unknown and the decisions is based on whether Lockdown mode is enabled
-6. If execution should be blocked, the daemon sends a `SIGKILL` to the target PID
-7. The daemon sends an ack message to the kernel to mark the completion as complete and allow the kernel to resume exec of the target binary (assuming it wasn't killed)
+# the allowlisted binary
+$ ./allowme
+i should be ALLOWED - my PID is 135
 
-## repo structure
+# the blocklisted binary
+$ ./blockme
+Killed
+
+# logs
+$ cat /var/log/santad.log
+Successfully daemonized the santad process...
+[...]
+[santa-DAEMON]: UNKNOWN (ALLOW) /usr/bin/santactl -> 2585c6fef89e4b231c2a8ef16779b6475a2f0678f7bb7deaa3ddd30e56a5d20b
+[santa-DAEMON]: ALLOWLISTED (ALLOW) /allowme -> f5d5379e0ec9b97813f546bd12029657b7c51135fcd8439bca9333ab1dfdf557
+[santa-DAEMON]: BLOCKLISTED (BLOCK) /blockme -> a92d9b7533984599bb263f703b5968db9a07f49aa6bb416faa535cd781debcbb
+[santa-DAEMON]: UNKNOWN (ALLOW) /usr/bin/coreutils -> 60271e6b1fee7fdfa8a4f25410bcfb6d6cb5e4c8ff236cb0b928ea577130a5da
+```
+
+## Features
+
+1. Multiple enforcement modes: Monitor mode for enforcing a blocklist policy only and Lockdown mode for enforcing an allowlist policy (i.e. only allowlisted binaries are allowed).
+2. SHA256-based rules: create allowlist/blocklist rules based on the SHA256 hash of target binaries. The ruleset can be provided via JSON file using a simple k:v format: `"<hash>: <rule>` or inserted at runtime using the `santactl rule insert` command.
+3. Hash Cache: the daemon implements a caching layer to avoid having to re-hash recently hashed files to improve performance. The cache is implemented as a fixed-size FIFO queue, and the oldest entries are only removed once the cache capacity is reached.
+
+## Known Issues/Limitations
+Extensive testing has not been done yet and this is very much still a proof-of-concept implementation. It's not meant to be functional on a full machine or even useful for anything practical at this point. That being said, there are a couple of known issues worth mentioning and that I plan on fixing:
+
+1. Commands that use pipes (i.e. `cat 123 | grep 123`) trigger the kprobe fault handler and cause errors. I still need to investigate the root cause.
+2. Concurrent executions _may_ cause unknown issues/failures. I haven't done much testing here but there may be issues with syncronizing/handling the kernel completion object used by the module in these cases. 
+
+## TODO & Unimplemented Features
+
+* [] Scope-based rules (i.e. path-based rules)
+* [] Cleaner exception handling in the daemon
+* [] Allow the daemon to re-checkin in case of failures
+* [] Improve IPC validation/authentication between components
+
+--- 
+
+# Architecture & Design
+
+## Execution Flow
+The sequence of events that take place on each execution and the process that Santa takes to make a decision on whether execution will be allowed or denied is described below.
+
+### Kernel
+1. The kernel module hooks calls to the kernel function `finalize_exec()` using a kprobe pre-handler. After a call to an execve variant, this function is called to complete the exec setup process, right before execution is actually handed to the binary’s entry point
+    - The module gets the PID of the process that is executing the target binary by reading from `task_struct *current`
+2. The kernel module sends a message containing the target PID to the daemon over a generic netlink socket. A kernel completion is initialized and waits for a response from the daemon without blocking (but still holding execution of the target binary).
+3. The kernel module will eventually receive a special “HASH DONE” message from the daemon which will trigger the completion to be marked as completed. The thread holding the execution fo the target binary is then resumed.
+
+### User-Space
+1. The daemon loops indefinitely, processes incoming messages from the kernel. Upon receiving a message it parses the PID from the message payload.
+2. The daemon gets the SHA256 hash of the target binary
+    - It first calculates a unique signature using file metadata and checks the cache to see if the signature is found. If it is, this hash is used.
+    - If the signature was not found in the cache, the daemon calculates the hash by reading from `/proc/<pid>/exe` and performing the shasum operation
+3. The daemon checks whether the hash is present on the blocklist or allowlist
+    - If on the allowlist: execution is allowed
+    - If on the blocklist: execution is blocked
+    - If neither: the file is unknown and the decisions is based on whether Lockdown mode is enabled
+4. If execution should be blocked, the daemon sends a `SIGKILL` signal to the target PID
+5. The daemon sends an ack message to the kernel to mark the completion as complete and allow the kernel to resume exec of the target binary (assuming it wasn't killed)
+
+## Components
+### Kernel Module
+
+The kernel module is responsible for the initial interception of the new execution and collecting required metadata that the daemon will need in order to make a final determination about whether execution will be allowed to continue or blocked.
+
+The module gathers the PID of the target binary as parsed from the `current` task struct and sends a message to the daemon in over a generic netlink socket using a custom protocol and command. The kernel module can also handle incoming netlink messages from the daemon.
+
+The module uses the kprobe kernel infrastructure to accomplish this hooking. Rather than hooking the `execve__*` syscall functions directly, the kprobe is applied to the function `finalize_exec()`; this is done because by the time that function is called we can be assured the target binary has been loaded into memory and the data in `/proc/<pid>/` has been updated. This ensures the correct data is read when the daemon reads `/proc/<pid>/exe` to get calculate the hash of the binary that will be executed. Hooking earlier in the exec process results in `/proc/<pid>/exe` always pointing to the shell binary from which the exec spawned.
+
+### Santa Daemon
+
+The daemon is reponsible for calculating the hash of the target binary and making execution decisions based on whether the target binary’s hash is allowlisted, blocklisted, or unknown. The daemon opens and binds to the kernel’s Netlink socket that it uses to establish a comms channel with the kernel module and wait for incoming messages. 
+
+Upon receiving a message from the kernel, the daemon parses the PID from the message payload and uses it to read from `/proc/<pid>/exe` in order to calculate the hash of the file being executed. Once the SHA256 hash has been calculated, the daemon checks whether the hash is present on either the allowlist or blocklist, and takes the appropriate action. If the hash is on neither, then it is unknown, and the execution decision is determined by the mode: block in Lockdown, allow in Monitor.
+
+### Santactl
+
+The `santactl` binary is used to interact with the daemon at runtime. It can be used to insert or remove rules, show known rules, and get daemon information such as the current mode and size of the ruleset. It also offers a feature for having the daemon’s policy engine analyze a target file and report whether it is known and would be allowed or blocked.
+
+## IPC
+
+Two different IPC mechanisms are used to handle bi-directional communication between the different components: Generic Netlink and Unix domain sockets.
+
+### Kernel-Daemon Communication: Generic Netlink
+
+The kernel module and daemon components communicate over a Netlink socket using a custom generic netlink protocol. The kernel module registers a new Netlink family and associated handlers for the different commands the protocol understands. There are 4 supported commands:
+
+```
+MSG - Generic message command
+CHECK-IN - Command the daemon sends to check-in w/ kernel
+DO-HASH - Command the kernel mod sends to daemon to init hash job
+HASH-DONE - Command the daemon sends the kernel to signal hash job completion
+```
+
+Messages are automatically validated by the kernel through the generic netlink interface and on the daemon side through Rust’s strong typing and exhaustive pattern checking.
+
+### Santactl-Daemon Communication: Unix Domain sockets
+
+Communication between the `santactl` and the daemon happens over standard Unix domain sockets. At runtime, the daemon creates and binds to a socket at `/opt/santa/santad.xpc` where it expects to receive messages from `santactl`. Similarly, `santactl` will create and bind to a socket at `/opt/santa/santactl.xpc` where it expects to receive responses back from the daemon. Each of these components connects to the other’s receiver socket to send messages. Messages are defined using structs that derive the `serde::Serialize` and `serde::Deserialize` traits, and are JSON serialized before being sent on the socket and deserialized back to their respective structs on the receiving end.
+
+---
+
+# Concepts
+## Mode
+
+The Santa daemon operates in one of two modes:
+
+- **Monitor:** executions are hooked and explicit blocklist rules are honored, but unknown binaries are allowed to run.
+- **Lockdown**: the same as monitor mode, except the default policy is to block any binary that is not explicitly allowlisted.
+
+The mode is currently hardcoded into the daemon binary and changing the mode requires recompiling the binary. 
+
+**TODO: Add option to switch modes using `santactl`.**
+
+WARNING: Lockdown mode will almost certainly bork the system and make it completely unusable without having hashed and allowlisted at least everything in `/bin:/usr/bin:/sbin:/usr/sbin` first. I haven’t tested this mode at all  yet.
+
+## Rules
+
+This current implementation only supports rules defined by the SHA256 hash of a target binary. The daemon reads the ruleset at runtime from a JSON file at `/opt/santa/rules.json`. This file has a simple format:
+
+```json
+{
+	"<hash>": "<ALLOW|BLOCK>"
+}
+```
+
+Its also possible to add or remove rules using the `santactl rule <insert|remove>` subcommands.
+
+Although the macOS version of Santa supports creating rules based on the signing certificate for signed applications, this doesn’t translate well to the Linux ecosystem since application signing is not really a thing there, so that likely won’t be added to this version. 
+
+**TODO: add support for scope-based rules (i.e. path-based allowlisting)** 
+
+## Cache
+
+The daemon implements a caching mechanism to keep the hashes of the most recently hashed files and avoid having to re-hash files on each execution, since that operations can be computationally expensive depending on the size of the target binary.
+
+The cache is implemented as a fixed-size FIFO queue using a combination of a `HashMap` and vector that tracks inserted keys in an ordered fashion. Upon reaching the cache capacity, the oldest keys in the vector queue are dropped and removed from the HashMap. Cache lookups get the benefit of HashMap lookup speeds.
+
+---
+
+# Binaries
+
+## santa-daemon
+
+```
+santa-daemon
+
+Usage: santa-daemon [OPTIONS]
+
+Options:
+  -d, --daemonize  Whether the process should daemonize or not
+  -h, --help       Print help information
+```
+
+**NOTE**: When the daemon is started with the `-d` flag to daemonize, it will log STDOUT to `/var/log/santad.log` and STDERR to `/var/log/santad_err.log`.
+
+## santactl
+
+```
+santactl is used to interact with the santa-daemon
+
+Usage: santactl <COMMAND>
+
+Commands:
+  status    Get status info from the daemon
+  fileinfo  Analyze and get info on a target file
+  rule      Manage the daemon's ruleset
+  help      Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help information
+```
+
+### Daemon Status
+This command can be used to query stats from the santa daemon.
+
+```bash
+$ santactl status
+{
+  "mode": "Monitor",
+  "rule_count": 2,
+  "cache_count": 4
+}
+```
+
+### Rule Management
+This command can be used to view and manage the ruleset at runtime.
+
+```
+Manage the daemon's ruleset
+
+Usage: santactl rule <COMMAND>
+
+Commands:
+  show    Show rules
+  insert  Insert rules
+  delete  Delete rules
+  help    Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help information
+```
+
+### File Info
+
+```
+Analyze and get info on a target file
+
+Usage: santactl fileinfo --path <PATH>
+
+Options:
+  -p, --path <PATH>
+  -h, --help         Print help information
+```
+
+```bash
+$ santactl fileinfo --path /testbin
+{
+  "filepath": "/testbin",
+  "hash": "ece6694532cee1c661623a6029a2f0563df841e0d2a7034077f7d8d86178ae8a",
+  "decision": "Allow",
+  "reason": "Unknown"
+}
+```
+---
+
+# Build and Run the Buildroot+QEMU Environment
+
+The `ext-tree/` directory contains an external buildroot tree pre-configured to build a 5.4.58 Linux kernel, the Santa kernel module and binaries, and a minimal root filesystem with everything included and configured to start at boot. The kernel image and root filesystem can be run via QEMU.
 
 ```
 ├── br-output
-├── docker
-│   ├── Dockerfile
-│   ├── container.sh
-│   └── init.sh
 ├── ext-tree
 │   ├── Config.in
 │   ├── configs
 │   ├── external.desc
 │   ├── external.mk
-│   ├── overlay
-│   └── package
-├── local-build.sh
-├── qemu-run.sh
-├── README.md
-└── src
-    ├── rust_santa_daemon
-    ├── santa_kmod
-    └── testbins
+│   ├── overlay/
+│   └── package/
 ```
 
 1. `ext-tree/`: the external buildroot tree preconfigured to build the kernel module and daemon, along with a 5.4.58 kernel and a root filesystem image containing the module and daemon.
@@ -50,29 +262,8 @@ At a high level, the sequence of events on each execution is as follows:
 4. `local-build.sh`: a convenience script to run a complete build of the buildroot environment and the santa packages
 4. `qemu-run.sh`: a convenience script to run a QEMU VM with the kernel and root filesystem images
 
-
-## example output
-
-
-```
-# /allowme
-[santa-DAEMON]: ALLOWLISTED (ALLOW) /allowme -> f5d5379e0ec9b97813f546bd12029657b7c51135fcd8439bca9333ab1dfdf557
-i should be ALLOWED - my PID is 112
-
-# /blockme
-[santa-DAEMON]: BLOCKLISTED application; killing pid 113
-[santa-DAEMON]: BLOCKLISTED (BLOCK) /blockme -> a92d9b7533984599bb263f703b5968db9a07f49aa6bb416faa535cd781debcbb
-Killed
-
-# /testbin
-[santa-DAEMON]: UNKNOWN (ALLOW) /testbin -> ece6694532cee1c661623a6029a2f0563df841e0d2a7034077f7d8d86178ae8a
-this is just a test - my PID is 114
-```
-
-## build and run via buildroot + qemu
+## build
 **NOTE: Local builds have only been tested on Ubuntu 20.04 and Debian 11.0 stable.**
-
-The `ext-tree/` directory contains an external buildroot tree preconfigured for the package.
 
 ### install dependencies
 ```bash
@@ -134,7 +325,7 @@ to rebuild the daemon component and filesystem image only, run this command from
 make -j12 rust_santa_daemon-rebuild; make -j12 all
 ```
 
-### rebuilding the kernel module:
+### rebuilding the kernel module
 
 to rebuild the kernel module and filesystem image only, run this command from the output directory (`br-output`):
 
@@ -143,7 +334,7 @@ make -j12 santa_kmod-rebuild; make -j12 all
 ```
 
 
-### running the image w/ QEMU
+## running the image w/ QEMU
 the resulting kernel image and root filesystem will have the kernel module and daemon binaries included, as well as config files to ensure both are automatically loaded and started at boot.
 
 the image can be run with QEMU using the following command:
@@ -164,33 +355,9 @@ qemu-system-x86_64                                                              
         -net nic,model=virtio -net user
 ```
 
----
+## santa auto-start in the vm
+The filesystem that is created as part of the buildroot VM contains files that will configure the Santa kernel module to be loaded and the santa-daemon process to start automatically at boot:
 
-## design
-
-### overview
-
-As mentioned above, there are two primary components: the kernel module and the userland daemon.
-
-### kernel module
-
-The kernel module is responsible for the initial interception of the new execution and collecting required metadata that the daemon will need in order to make a final determination about whether execution will be allowed to continue or blocked.
-
-The module uses the kprobe kernel infrastructure to accomplish this hooking. Rather than hooking the `execve__*` syscall functions directly, the kprobe is applied to the function `finalize_exec()`; this is done because by the time that function is called we can be assured the target binary has been loaded into memory and the data in `/proc/<pid>/` has been updated. This ensures the correct data is read when the daemon reads `/proc/<pid>/exe` to get calculate the hash of the binary that will be executed. Hooking earlier in the exec process results in `/proc/<pid>/exe` always pointing to the shell binary (i.e. because the execve hasn't completed so the process still contains the memory of whichever process it's fork()'ed from).
-
-The module gathers the PID of the target binary as parsed from the `current` task struct and sends a message to the daemon in over a generic netlink socket using a custom protocol and command. The kernel module can also handle incoming netlink messages from the daemon.
-
-
-### userland daemon
-The daemon is reponsible for calculating the hash of the target binary and making an execution decision based on whether the hash is allowed, blocked, or unknown.
-
-The daemon opens and binds to a Netlink socket that it uses to establish a comms channel with the kernel module and wait for incoming messages. When the daemon first starts up and opens the Netlink socket, it sends a special CHECK-IN message to the kernel module which the module then uses to know where to send it's messages. Upon receiving a message from the kernel, the daemon parses the PID from the message; the PID is then used to read from `/proc/<pid>/exe` in order to calculate the hash of the file being executed. Once the SHA256 hash has been calculated, the daemon checks whether the hash is present on either the allowlist or blocklist, and takes the appropriate action. If the hash is on neither, then it is unknown, and the execution decision is determined by the mode: block in Lockdown, allow in Monitor.
-
-Reading from `/proc/<pid>/exe` has the benefit that it avoids running into time-of-check vs. time-of-use issues. Attempting to have the daemon use the file path alone resulted in at least 2 reads happening: once at execution time when the binary is loaded into the process space and once when the daemon would read the file to calculate the hash. Theoretically, this could introduce a race condition where a 'bad' file gets read into the process memory at execution but is replaced with a 'good' file before the daemon reads from that path for hashing, resulting in the daemon saying "yes, allowed" incorrectly. The data at `/proc/<pid>/exe` is actually the raw entrypoint into the file handle that was opened for the execution of that process, not a regular symlink to the file on the filesystem. So, even though it seems like two reads still happen, its actually 're-reading' from the same read, as the file handle is the same and points to the data in memory, not on disk -- so replacing/removing the data on disk would make no difference. We can be sure the hash we calculated is for the same executable that's been loaded in the process that will either be allowed or blocked.
-
-### daemon hash cache implementation
-TODO
-
-### kernel-userland communication via netlink
-TODO
+- `ext-tree/overlay/etc/init.d/S90modules`
+- `ext-tree/overlay/etc/init.d/S99santa_daemon`
 

--- a/ext-tree/overlay/etc/init.d/S99santa_daemon
+++ b/ext-tree/overlay/etc/init.d/S99santa_daemon
@@ -4,7 +4,7 @@ DAEMON="santa-daemon"
 # and use "-m" to instruct start-stop-daemon to create one.
 start() {
         printf 'Starting %s: ' "$DAEMON"
-        /usr/bin/"$DAEMON" &
+        /usr/bin/"$DAEMON" -d
         status=$?
         if [ "$status" -eq 0 ]; then
                 echo "OK"

--- a/src/rust_santa_daemon/src/libsanta/cache.rs
+++ b/src/rust_santa_daemon/src/libsanta/cache.rs
@@ -4,38 +4,7 @@ use std::time::SystemTime;
 use std::collections::HashMap;
 use std::os::linux::fs::MetadataExt;
 
-/// Tests
-#[test]
-fn cache_insert_to_capacity() {
-    let capacity = 1000;
-    let hashy = "hashahshahhsa";
-    let mut sig = CacheSignature::new("/etc/profile");
-    let mut cache = SantaCache::new(capacity);
-    for _ in 1..capacity {
-        cache.insert(sig.to_string(), hashy.to_string());
-        // mutate the signature so we have unique sigs on each iteration
-        sig.created = sig.created + 1;
-    }
-    assert_eq!(cache.buffer.len(), capacity-1);
-}
-
-
-#[test]
-fn cache_capacity_is_maintained() {
-    let capacity = 1000;
-    let hashy = "hashahhs";
-    let mut sig = String::from("/ile");
-    let mut cache = SantaCache::new(capacity);
-    for _ in 1..(capacity*2) {
-        cache.insert(sig.to_string(), hashy.to_string());
-        // mutate the signature so we have unique sigs on each iteration
-        sig = String::from(format!("{}x", sig));
-    }
-    // the hashmap should not have expanded past capacity-1 entries
-    assert_eq!(cache.buffer.len(), capacity-1);
-    // the keyvec should not have expanded past capacity-1 entries
-    assert_eq!(cache.keyvec.len(), capacity-1);
-}
+use std::error::Error;
 
 /// SantaCacheSignature
 #[derive(Clone, Eq, PartialEq)]
@@ -54,29 +23,25 @@ impl CacheSignature {
 
 // CacheSignature implementation
 impl CacheSignature {
-    pub fn new(filepath: &str) -> CacheSignature {
+    pub fn new(filepath: &str) -> Result<CacheSignature, Box<dyn Error>> {
         // get file metadata for signature
         let meta = fs::metadata(filepath).expect("should be able to read file");
         // mod time
-        let last_mod = meta.modified()
-            .expect("should be on a unix system")
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .expect("should be able to get duration")
+        let last_mod = meta.modified()?
+            .duration_since(SystemTime::UNIX_EPOCH)?
             .as_secs();
         // created
-        let created = meta.created()
-            .expect("should be on a unix system")
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .expect("should be able to get duration")
+        let created = meta.created()?
+            .duration_since(SystemTime::UNIX_EPOCH)?
             .as_secs();
         // inode
         let inode = meta.st_ino();
 
-        CacheSignature {
+        Ok(CacheSignature {
             inode,
             last_mod,
             created,
-        }
+        })
     }
 }
 

--- a/src/rust_santa_daemon/src/libsanta/cache.rs
+++ b/src/rust_santa_daemon/src/libsanta/cache.rs
@@ -107,6 +107,7 @@ impl SantaCache {
         }
     }
 
+    /// Get the current number of items in the cache
     pub fn len(&self) -> usize {
         self.buffer.len()
     }

--- a/src/rust_santa_daemon/src/libsanta/commands.rs
+++ b/src/rust_santa_daemon/src/libsanta/commands.rs
@@ -1,0 +1,59 @@
+use crate::engine::PolicyRule;
+use crate::Jsonify;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum CommandTypes {
+    Status,
+    FileInfo,
+    Rule,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+pub enum RuleAction {
+    Insert,
+    Remove,
+    Display,
+    Unknown,
+}
+
+impl From<String> for RuleAction {
+    fn from(action: String) -> RuleAction {
+        match &action[..] {
+            "show" => {
+                RuleAction::Display
+            },
+            "insert" => {
+                RuleAction::Display
+            },
+            "delete" => {
+                RuleAction::Display
+            },
+            _ => {RuleAction::Unknown},
+        }
+
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct RuleCommand {
+    action: RuleAction,
+    hash: Option<String>,
+    policy: Option<PolicyRule>,
+}
+impl Jsonify for RuleCommand {}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct StatusCommand {}
+impl Jsonify for StatusCommand {}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct FileInfoCommand { pub path: String }
+impl Jsonify for FileInfoCommand {}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SantaCtlCommand {
+    pub ctype: CommandTypes,
+    pub command: String,
+}
+impl Jsonify for SantaCtlCommand {}

--- a/src/rust_santa_daemon/src/libsanta/commands.rs
+++ b/src/rust_santa_daemon/src/libsanta/commands.rs
@@ -1,6 +1,7 @@
 use crate::engine::PolicyRule;
 use crate::Jsonify;
 use serde::{Deserialize, Serialize};
+use clap::Subcommand;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum CommandTypes {
@@ -9,37 +10,18 @@ pub enum CommandTypes {
     Rule,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+#[derive(Subcommand, Serialize, Deserialize, Debug, Clone, Copy)]
 pub enum RuleAction {
     Insert,
     Remove,
-    Display,
-    Unknown,
-}
-
-impl From<String> for RuleAction {
-    fn from(action: String) -> RuleAction {
-        match &action[..] {
-            "show" => {
-                RuleAction::Display
-            },
-            "insert" => {
-                RuleAction::Display
-            },
-            "delete" => {
-                RuleAction::Display
-            },
-            _ => {RuleAction::Unknown},
-        }
-
-    }
+    Show,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RuleCommand {
-    action: RuleAction,
-    hash: Option<String>,
-    policy: Option<PolicyRule>,
+    pub action: RuleAction,
+    pub hash: String,
+    pub policy: PolicyRule,
 }
 impl Jsonify for RuleCommand {}
 

--- a/src/rust_santa_daemon/src/libsanta/consts.rs
+++ b/src/rust_santa_daemon/src/libsanta/consts.rs
@@ -1,0 +1,12 @@
+
+// Constants
+pub const SANTAD_NAME: &str = "[santa-DAEMON]";
+pub const SANTACTL_NAME: &str = "[santactl]";
+pub const SANTA_BASE_PATH: &str = "/opt/santa";
+pub const RULES_DB_PATH: &str = "/opt/santa/rules.json";
+pub const XPC_SOCKET_PATH: &str = "/opt/santa/santa.xpc";
+pub const XPC_CLIENT_PATH: &str = "/opt/santa/santactl.xpc";
+pub const XPC_SERVER_PATH: &str = "/opt/santa/santad.xpc";
+
+pub const SANTA_LOG: &str = "/var/log/santad.log";
+pub const SANTA_ERRLOG: &str = "/var/log/santad_err.log";

--- a/src/rust_santa_daemon/src/libsanta/engine.rs
+++ b/src/rust_santa_daemon/src/libsanta/engine.rs
@@ -1,6 +1,7 @@
 // std imports
-use std::{io, fs};
+use std::{io, fs, fmt};
 use std::collections::HashMap;
+use clap::ValueEnum;
 use nix::sys::signal;
 use nix::unistd::Pid;
 
@@ -14,10 +15,19 @@ use crate::cache::{SantaCache, CacheSignature};
 
 /// Enum of policy decisions returned during hash validation checks
 #[allow(dead_code)]
-#[derive(Deserialize, Serialize, Debug, Clone, Copy)]
+#[derive(Deserialize, Serialize, Debug, Clone, Copy, ValueEnum)]
 pub enum PolicyRule {
     Allow,
     Block,
+}
+
+impl fmt::Display for PolicyRule {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PolicyRule::Allow => write!(f, "Allowlist"),
+            PolicyRule::Block => write!(f, "Blocklist"),
+        }
+    }
 }
 
 /// PolicyDecisionReason: the reason for a given policy decision
@@ -56,6 +66,7 @@ impl ToString for PolicyDecisionReason {
 pub enum PolicyDecision {
     Allow,
     Block,
+    Invalid,
 }
 
 /// Convert a PolicyDecision to String
@@ -64,6 +75,7 @@ impl ToString for PolicyDecision {
         match self {
             PolicyDecision::Allow => String::from("ALLOW"),
             PolicyDecision::Block => String::from("BLOCK"),
+            PolicyDecision::Invalid => String::from("INVALID")
         }
     }
 }
@@ -167,6 +179,7 @@ pub struct PolicyEngine {
     pub rules: HashMap<String, PolicyRule>,
     cache: SantaCache,
 }
+impl Jsonify for HashMap<String, PolicyRule> {}
 
 /// PolicyEngine implementation
 impl PolicyEngine {

--- a/src/rust_santa_daemon/src/libsanta/lib.rs
+++ b/src/rust_santa_daemon/src/libsanta/lib.rs
@@ -1,25 +1,14 @@
 pub mod netlink;
-pub mod daemon;
 pub mod uxpc;
 pub mod engine;
+pub mod commands;
+pub mod consts;
 mod cache;
 
 use std::fmt;
-
-// Constants
-pub const SANTAD_NAME: &str = "[santa-DAEMON]";
-pub const NL_SANTA_PROTO: u8 = 30;
-pub const NL_SANTA_FAMILY_NAME: &str = "gnl_santa";
-
-pub const SANTA_BASE_PATH: &str = "/opt/santa";
-pub const RULES_DB_PATH: &str = "/opt/santa/rules.json";
-pub const XPC_SOCKET_PATH: &str = "/opt/santa/santa.xpc";
-pub const XPC_CLIENT_PATH: &str = "/opt/santa/santactl.xpc";
-pub const XPC_SERVER_PATH: &str = "/opt/santa/santad.xpc";
-
-// status command
-pub const STATUS_CMD: &str = "status";
-
+use serde::Serialize;
+use serde_json::json;
+use consts::{SANTACTL_NAME, SANTAD_NAME};
 
 /// SantaMode Enum
 #[derive(Clone, Copy)]
@@ -34,6 +23,36 @@ impl fmt::Display for SantaMode {
         match self {
             SantaMode::Lockdown => write!(f, "Lockdown"),
             SantaMode::Monitor => write!(f, "Monitor"),
+        }
+    }
+}
+
+/// Trait for types that support being json-ified to simplify doing so.
+pub trait Jsonify: Serialize {
+    fn jsonify(&self) -> String {
+        let js = json!(self);
+        js.to_string()
+    }
+
+    fn jsonify_pretty(&self) -> String {
+        serde_json::to_string_pretty(self)
+            .unwrap_or(self.jsonify())
+    }
+}
+
+pub trait Loggable {
+    fn log(&self, src: LoggerSource);
+}
+
+pub enum LoggerSource {
+    SantaDaemon,
+    SantaCtl,
+}
+impl ToString for LoggerSource {
+    fn to_string(&self) -> String {
+        match self {
+            LoggerSource::SantaCtl => String::from(SANTACTL_NAME),
+            LoggerSource::SantaDaemon => String::from(SANTAD_NAME),
         }
     }
 }

--- a/src/rust_santa_daemon/src/libsanta/netlink.rs
+++ b/src/rust_santa_daemon/src/libsanta/netlink.rs
@@ -24,10 +24,9 @@ pub enum NlSantaCommand {
     // We expect MSG commands to have NlSantaAttribute:Msg
     Msg = 1,        // Generic message type (string)
     MsgCheckin = 2, // Checkin from agent (string)
-    MsgGetPid = 3,  // Command for GetPID
+    MsgDoHash = 3, // Checkin from agent (string)
     MsgHashDone = 4,// Agent finished hash operation
     ReplyWithNlmsgErr = 5,
-    MsgGetRules = 6,
 }
 // Implement necessary trait for the neli lib on the NlSantaCommand enum.
 impl neli::consts::genl::Cmd for NlSantaCommand{}
@@ -40,8 +39,6 @@ pub enum NlSantaAttribute {
     Unspec = 0,
     // We expect MSG attributes to be NULL terminated C strings
     Msg = 1,
-    MsgCheckin = 2,
-    MsgHashDone = 3,
 }
 // Implement necessary trait for the neli lib on the NlSantaAttribute enum.
 impl neli::consts::genl::NlAttrType for NlSantaAttribute{}

--- a/src/rust_santa_daemon/src/libsanta/netlink.rs
+++ b/src/rust_santa_daemon/src/libsanta/netlink.rs
@@ -1,6 +1,8 @@
-use crate::{NL_SANTA_PROTO, NL_SANTA_FAMILY_NAME};
 use std::process;
 use std::error::Error;
+
+pub const NL_SANTA_PROTO: u8 = 30;
+pub const NL_SANTA_FAMILY_NAME: &str = "gnl_santa";
 
 // neli import for Netlink support
 #[allow(unused_imports)]
@@ -46,20 +48,20 @@ impl neli::consts::genl::NlAttrType for NlSantaAttribute{}
 
 
 /// Netlink socket wrapper object with send and recv methods
-pub struct NetlinkAgentGeneric {
+pub struct NetlinkAgent {
     pub family_id: u16,
     pub socket: NlSocketHandle,
     pub groups: Vec<u32>,
 }
 
-/// NetlinkAgentGeneric implementation.
-impl NetlinkAgentGeneric {
+/// NetlinkAgent implementation.
+impl NetlinkAgent {
     /// Create a new instance of a NetlinkAgent.
     /// Example:
     /// ```
-    /// let agent = NetlinkAgentGeneric::new(Some(0), &[]);
+    /// let agent = NetlinkAgent::new(Some(0), &[]);
     /// ```
-    pub fn new(pid: Option<u32>, groups: &[u32]) -> NetlinkAgentGeneric {
+    pub fn new(pid: Option<u32>, groups: &[u32]) -> NetlinkAgent {
         // create and bind the socket
         let mut socket = NlSocketHandle::connect(
             NlFamily::Generic,
@@ -71,14 +73,14 @@ impl NetlinkAgentGeneric {
         let family_id = socket.resolve_genl_family(NL_SANTA_FAMILY_NAME)
             .expect("the kernel module should be loaded before running the daemon");
 
-        NetlinkAgentGeneric { family_id, socket, groups: Vec::from(groups) }
+        NetlinkAgent { family_id, socket, groups: Vec::from(groups) }
     }
 
     /// Send a specific `NlSantaCommand` and message payload via Netlink; the socket handle passed
     /// in should already be initialized and bound using `NlSocketHandle::connect()`.
     /// Example:
     /// ```
-    /// let agent = NetlinkAgentGeneric::new(Some(0), &[]);
+    /// let agent = NetlinkAgent::new(Some(0), &[]);
     /// agent.send_cmd(NlSantaCommand::Msg, "hello")?;
     /// ```
     pub fn send_cmd(&mut self, command: NlSantaCommand, 
@@ -125,7 +127,7 @@ impl NetlinkAgentGeneric {
     /// Receive a netlink message using the opened socket
     /// Example:
     /// ```
-    /// let agent = NetlinkAgentGeneric::new(Some(0), &[]);
+    /// let agent = NetlinkAgent::new(Some(0), &[]);
     /// let res = agent.recv().unwrap();
     /// let msg = res.get_payload().unwrap();
     /// let attr_handle = msg.get_attr_handle().unwrap();
@@ -133,16 +135,41 @@ impl NetlinkAgentGeneric {
     ///     get_attr_payload_as_with_len::<String>(NlSantaAttribute::Msg).unwrap();
     /// ```
     pub fn recv(&mut self)
-                -> Option<Nlmsghdr<u16, Genlmsghdr<NlSantaCommand, NlSantaAttribute>>> {
+                -> Result<Option<(NlSantaCommand, String)>, String> {
         // If the socket is in non-blocking mode the Result'ing Option may be None if no
         // data could be immediately read from the socket, which isn't an issue. In blocking
         // mode, the Result will either be Some(Nlmsghdr) or NlError; errors are an issue regardless
         // of the blocking context.
         match self.socket.recv() {
-            Ok(msg) => msg,
+            Ok(msg) => {
+                let mess: Option<Nlmsghdr<u16, Genlmsghdr<NlSantaCommand, NlSantaAttribute>>> = msg;
+                match mess {
+                    // Some means we were able to read a message from the socket
+                    Some(x) => {
+                        if let Ok(pay) = x.get_payload() {
+                            let cmd: NlSantaCommand = pay.cmd;
+                            let attr_handle = pay.get_attr_handle();
+                            let x = attr_handle.get_attr_payload_as_with_len::<String>(NlSantaAttribute::Msg);
+                            if let Ok(payload) = x {
+                                return Ok(Some((cmd, payload)))
+                            } else {
+                                return Err("failed to parse payload from the attr".to_string())
+                            }
+                        } else {
+                            return Err("failed to get payload from nlmsgh header".to_string())
+                        }
+                    }
+                    // None means a message couldn't be immediately read from the socket, which is okay
+                    // since the netlink socket it set to be non-blocking; we just move on and try to read again
+                    // on the next iteration
+                    None => {
+                        return Ok(None)
+                    }
+                }
+            },
             Err(e) => {
-                eprintln!("error on netlink recv(): {}", e);
-                None
+                let err = format!("error on netlink recv: {e}");
+                Err(err.to_string())
             }
         }
     }

--- a/src/rust_santa_daemon/src/libsanta/netlink.rs
+++ b/src/rust_santa_daemon/src/libsanta/netlink.rs
@@ -61,19 +61,18 @@ impl NetlinkAgent {
     /// ```
     /// let agent = NetlinkAgent::new(Some(0), &[]);
     /// ```
-    pub fn new(pid: Option<u32>, groups: &[u32]) -> NetlinkAgent {
+    pub fn new(pid: Option<u32>, groups: &[u32]) -> Result<NetlinkAgent, Box<dyn Error>> {
         // create and bind the socket
         let mut socket = NlSocketHandle::connect(
             NlFamily::Generic,
             pid,
             groups,
-        ).expect("socket should be created");
+        )?;
 
         // resolve family ID
-        let family_id = socket.resolve_genl_family(NL_SANTA_FAMILY_NAME)
-            .expect("the kernel module should be loaded before running the daemon");
+        let family_id = socket.resolve_genl_family(NL_SANTA_FAMILY_NAME)?;
 
-        NetlinkAgent { family_id, socket, groups: Vec::from(groups) }
+        Ok(NetlinkAgent { family_id, socket, groups: Vec::from(groups) })
     }
 
     /// Send a specific `NlSantaCommand` and message payload via Netlink; the socket handle passed

--- a/src/rust_santa_daemon/src/santa-daemon/daemon.rs
+++ b/src/rust_santa_daemon/src/santa-daemon/daemon.rs
@@ -24,7 +24,7 @@ impl SantaDaemon {
         }
 
         let mut daemon = SantaDaemon {
-            netlink: NetlinkAgent::new(Some(0), &[]),
+            netlink: NetlinkAgent::new(Some(0), &[])?,
             engine: PolicyEngine::new(mode, 1000),
             xpc_rx: SantaXpcServer::new(String::from(XPC_SOCKET_PATH), true),
         };
@@ -33,7 +33,7 @@ impl SantaDaemon {
     }
 
     /// Initialize the daemon
-    fn init(&mut self) -> Result<(), String> {
+    fn init(&mut self) -> Result<(), Box<dyn Error>> {
         // Check in with the kernel
         self.checkin()?;
 
@@ -52,14 +52,9 @@ impl SantaDaemon {
     }
 
     /// Do check-in with the kernel module
-    fn checkin(&mut self) -> Result<(), String> {
-        self.netlink.send_cmd(NlSantaCommand::MsgCheckin, &"")
-            .expect("failed to send msg");
-        // receive a response (we don't do anything with it though)
-        if let Err(err) = self.netlink.recv() {
-            eprintln!("Error on Check-In: {err}");
-            return Err(err)
-        }
+    fn checkin(&mut self) -> Result<(), Box<dyn Error>> {
+        self.netlink.send_cmd(NlSantaCommand::MsgCheckin, &"")?;
+        self.netlink.recv()?;
         Ok(())
     }
 }

--- a/src/rust_santa_daemon/src/santa-daemon/daemon.rs
+++ b/src/rust_santa_daemon/src/santa-daemon/daemon.rs
@@ -1,43 +1,47 @@
-use crate::{SantaMode, SANTA_BASE_PATH, XPC_SOCKET_PATH};
-use crate::netlink::{NetlinkAgentGeneric, NlSantaCommand};
-use crate::engine::PolicyEngine;
-use crate::uxpc::{SantaXpcServer};
+use libsanta::consts::{SANTA_BASE_PATH, XPC_SOCKET_PATH};
+use libsanta::netlink::{NetlinkAgent, NlSantaCommand};
+use libsanta::engine::PolicyEngine;
+use libsanta::SantaMode;
+use libsanta::uxpc::{SantaXpcServer};
 use std::path::Path;
+use std::error::Error;
+
 
 /// SantaDaemon object
 pub struct SantaDaemon {
-    pub netlink: NetlinkAgentGeneric,
+    pub netlink: NetlinkAgent,
     pub engine: PolicyEngine,
     pub xpc_rx: SantaXpcServer,
 }
 
 /// A SantaDaemon instance
 impl SantaDaemon {
-    pub fn new(mode: SantaMode) -> SantaDaemon {
+    pub fn new(mode: SantaMode) -> Result<SantaDaemon, Box<dyn Error>> {
         // ensure the /opt/santa directory exists
         let santa_base = Path::new(SANTA_BASE_PATH);
         if !santa_base.exists() {
-            std::fs::create_dir(santa_base).unwrap();
+            std::fs::create_dir_all(santa_base)?;
         }
 
         let mut daemon = SantaDaemon {
-            netlink: NetlinkAgentGeneric::new(Some(0), &[]),
+            netlink: NetlinkAgent::new(Some(0), &[]),
             engine: PolicyEngine::new(mode, 1000),
             xpc_rx: SantaXpcServer::new(String::from(XPC_SOCKET_PATH), true),
         };
-        daemon.init();
-        daemon
+        daemon.init()?;
+        Ok(daemon)
     }
 
     /// Initialize the daemon
-    fn init(&mut self) {
+    fn init(&mut self) -> Result<(), String> {
         // Check in with the kernel
-        self.checkin();
+        self.checkin()?;
 
         // NOTE: the daemon's netlink socket is set to be nonblocking so that both
         // the netlink socket and the unix xpc socket can be processed without
         // blocking each other.
         self.set_nonblocking();
+        Ok(())
     }
 
     /// Set the netlink socket to non-blocking
@@ -48,10 +52,14 @@ impl SantaDaemon {
     }
 
     /// Do check-in with the kernel module
-    fn checkin(&mut self) {
+    fn checkin(&mut self) -> Result<(), String> {
         self.netlink.send_cmd(NlSantaCommand::MsgCheckin, &"")
             .expect("failed to send msg");
         // receive a response (we don't do anything with it though)
-        self.netlink.recv();
+        if let Err(err) = self.netlink.recv() {
+            eprintln!("Error on Check-In: {err}");
+            return Err(err)
+        }
+        Ok(())
     }
 }

--- a/src/rust_santa_daemon/src/santa-daemon/main.rs
+++ b/src/rust_santa_daemon/src/santa-daemon/main.rs
@@ -1,17 +1,24 @@
 /// Rust implementation of the Santa daemon
+mod daemon;
+use daemon::SantaDaemon;
+
 use std::error::Error;
-use std::fs::File;
+use std::fs::OpenOptions;
+use std::path::Path;
 
 use daemonize::Daemonize;
 use clap::Parser;
 
-use libsanta::{SANTAD_NAME, XPC_CLIENT_PATH, STATUS_CMD, SantaMode};
-use libsanta::netlink::{NlSantaCommand, NlSantaAttribute};
-use libsanta::daemon::SantaDaemon;
-use libsanta::engine::PolicyEngineStatus;
-use libsanta::uxpc::SantaXpcClient;
+use libsanta::{SantaMode, Loggable, LoggerSource, Jsonify};
+use libsanta::{
+    netlink::NlSantaCommand,
+    commands::{SantaCtlCommand, RuleCommand, FileInfoCommand, CommandTypes},
+    engine::{PolicyDecision, PolicyEngineTarget},
+    uxpc::SantaXpcClient,
+    consts::{SANTAD_NAME, XPC_CLIENT_PATH, SANTA_LOG, SANTA_ERRLOG},
+};
 
-/// Cli argument parser via clap
+/// santa-daemon
 #[derive(Parser)]
 struct Cli {
     /// Whether the process should daemonize or not 
@@ -19,59 +26,78 @@ struct Cli {
     daemonize: bool,
 }
 
+/// The main worker loop that handles incoming messages
 fn worker_loop() -> Result<(), Box<dyn Error>> {
     // instantiate the daemon instance
-    let mut daemon = SantaDaemon::new(SantaMode::Monitor);
+    let mut daemon = SantaDaemon::new(SantaMode::Monitor)?;
 
     // do stuff forever
     loop {
         // Check for messages from the kernel on the netlink socket
-        if let Some(nlmsg) = daemon.netlink.recv() {
-            // we got a request, parse the payload
-            let res = nlmsg;
-            if let Ok(msg) = res.get_payload() {
-                // get the command and a handle to the attributes
-                let cmd: NlSantaCommand = msg.cmd;
-                let attr_handle = msg.get_attr_handle();
+        match daemon.netlink.recv() {
+            Ok(res) => {
+                // No errors on the recv(), lets check if we got a message
+                if let Some((cmd, payload)) = res {
+                    match cmd {
+                        NlSantaCommand::Msg => {
+                            // get an answer
+                            let target = PolicyEngineTarget::from(payload.clone());
+                            let answer = daemon.engine.analyze(target);
+                            // log the answer
+                            answer.log(LoggerSource::SantaDaemon);
 
-                // Handle commands
-                match cmd {
-                    NlSantaCommand::Msg => {
-                        // parse out payload
-                        match attr_handle
-                            .get_attr_payload_as_with_len::<String>(NlSantaAttribute::Msg) {
-                            Ok(pid) => {
-                                // get an answer
-                                let answer = daemon.engine.analyze(&pid);
-                                // log the answer
-                                answer.log();
-                                // let the kernel know we're done, don't expect a response
-                                daemon.netlink.send_cmd(NlSantaCommand::MsgHashDone, &"")?;
-                            },
-                            Err(_) => eprintln!("{SANTAD_NAME}: invalid message form"),
-                        }
-                    },
-                    _ => eprintln!("{SANTAD_NAME}: received unknown command"),
+                            // kill the process if it should be blocked
+                            if let PolicyDecision::Block = answer.decision {
+                                daemon.engine.kill(String::from(payload));
+                            }
+
+                            // let the kernel know we're done, don't expect a response
+                            daemon.netlink.send_cmd(NlSantaCommand::MsgHashDone, &"")?;
+                        },
+                        _ => eprintln!("{SANTAD_NAME}: received unknown command"),
+                    }
                 }
-            } else {
-                eprintln!("{SANTAD_NAME}: Failed to read paylod from generic netlink message");
-            }
-        };
+            },
+            Err(err) => eprintln!("{SANTAD_NAME}: {err}"),
+        }
         // Check for messages on the xpc socket
         if let Some(data) = daemon.xpc_rx.recv() {
-            match &data[..] {
-                STATUS_CMD => {
-                    let status: PolicyEngineStatus = daemon.engine.get_status();
-                    let status_json = serde_json::to_string_pretty(&status)
-                        .expect("should be able to pretty print json string");
-                    let mut xclient = SantaXpcClient::new(String::from(XPC_CLIENT_PATH));
-                    xclient.send(status_json.as_bytes()).expect("daemon sent message to client");
-                },
-                _ => {},
-            };
+            if let Ok(_asdf) = serde_json::from_str::<SantaCtlCommand>(&data) {
+                match _asdf.ctype {
+                    CommandTypes::Status => {
+                        let status = daemon.engine.get_status().jsonify_pretty();
+                        let mut xclient = SantaXpcClient::new(String::from(XPC_CLIENT_PATH));
+                        if let Err(err) = xclient.send(status.as_bytes()) {
+                            eprintln!("{SANTAD_NAME}: Failed to send message to XPC client - {err}")
+                        }
+                    },
+                    CommandTypes::FileInfo => {
+                        if let Ok(cmd) = serde_json::from_str::<FileInfoCommand>(&_asdf.command) {
+                            let target = PolicyEngineTarget::from(cmd.path);
+                            let answer = daemon.engine.analyze(target).jsonify_pretty();
+                            let mut xclient = SantaXpcClient::new(String::from(XPC_CLIENT_PATH));
+                            if let Err(err) = xclient.send(answer.as_bytes()) {
+                                eprintln!("{SANTAD_NAME}: Failed to send message to XPC client - {err}")
+                            }
+                        } else {
+                            eprintln!("Invalid message format for FileInfoCommand: {}", _asdf.command)
+                        }
+                    },
+                    CommandTypes::Rule => {
+                        if let Ok(_cmd) = serde_json::from_str::<RuleCommand>(&_asdf.command) {
+                        } else {
+                            eprintln!("Invalid message format for FileInfoCommand: {}", _asdf.command)
+                        }
+                    },
+                }
+            }
+            else {
+                eprintln!("Invalid message format for SantaCtlCommand: {}", data)
+            }
         };
     };
 }
+
 
 /// Main
 fn main() -> Result<(), Box<dyn Error>> {
@@ -80,30 +106,42 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // determine whether we should fork to the background or run normally
     println!("{SANTAD_NAME}: Entering main message processing loop...");
-    match args.daemonize {
-        true => {
-            let stderr = File::create("/var/log/santad_err.log")
-                .expect("should have write access to /var/log");
-            let stdout = File::create("/var/log/santad.log")
-                .expect("should have write access to /var/log");
-            let daemonized = Daemonize::new()
-                .stderr(stderr)
-                .stdout(stdout);
+    if args.daemonize {
+        let stderr_path = Path::new(SANTA_ERRLOG);
+        let stderr = match OpenOptions::new().append(true).create(true).open(stderr_path) {
+            Ok(file) => {file},
+            Err(e) => {
+                eprintln!("Error: {e}");
+                return Ok(())
+            },
+        };
 
-            // main loop
-            match daemonized.start() {
-                Ok(_) => {
-                    println!("Successfully daemonized the santad process...");
-                    // do stuff forever
-                    worker_loop().unwrap();
-                }
-                Err(err) => eprintln!("Failed to daemonize the process: {err}"),
-            };
-        },
-        false => {
-            // do stuff forever
-            worker_loop().unwrap();
-        },
-    };
+        let stdout_path = Path::new(SANTA_LOG);
+        let stdout = match OpenOptions::new().append(true).create(true).open(stdout_path) {
+            Ok(file) => {file},
+            Err(e) => {
+                eprintln!("Error: {e}");
+                return Ok(())
+            },
+        };
+
+        // create the daemon instance with stdout/stderr redirection
+        let daemonized = Daemonize::new()
+            .stderr(stderr)
+            .stdout(stdout);
+
+        match daemonized.start() {
+            Ok(_) => {
+                // do stuff forever
+                println!("Successfully daemonized the santad process...");
+                worker_loop().unwrap();
+            }
+            Err(err) => eprintln!("Failed to daemonize the process: {err}"),
+        };
+    } else {
+        // do stuff forever
+        worker_loop().unwrap();
+    }
+
     Ok(())
 }

--- a/src/rust_santa_daemon/src/santa-daemon/main.rs
+++ b/src/rust_santa_daemon/src/santa-daemon/main.rs
@@ -40,7 +40,7 @@ fn worker_loop() -> Result<(), Box<dyn Error>> {
                 // No errors on the recv(), lets check if we got a message
                 if let Some((cmd, payload)) = res {
                     match cmd {
-                        NlSantaCommand::Msg => {
+                        NlSantaCommand::MsgDoHash => {
                             // get an answer
                             let target = PolicyEngineTarget::from(payload.clone());
                             let answer = daemon.engine.analyze(target);

--- a/src/rust_santa_daemon/src/santactl/main.rs
+++ b/src/rust_santa_daemon/src/santactl/main.rs
@@ -1,21 +1,79 @@
-// Local imports
-use libsanta::uxpc::{SantaXpcClient, SantaXpcServer};
-use libsanta::{XPC_SOCKET_PATH, XPC_CLIENT_PATH};
 use std::time::Duration;
 use std::thread;
+use clap::{Parser, Subcommand};
+
+// Local imports
+use libsanta::Jsonify;
+use libsanta::consts::{XPC_SOCKET_PATH, XPC_CLIENT_PATH};
+use libsanta::uxpc::{SantaXpcClient, SantaXpcServer};
+use libsanta::commands::{CommandTypes, SantaCtlCommand, RuleAction, StatusCommand, FileInfoCommand};
+
+/// santactl is used to interact with the santa-daemon
+#[derive(Parser)]
+struct Cli {
+    /// Subcommands 
+    #[command(subcommand)]
+    command: SubCommands,
+}
+
+#[derive(Subcommand)]
+pub enum SubCommands {
+    /// Get status info from the daemon
+    Status,
+    /// Analyze and get info on a target file
+    Fileinfo {
+        #[arg(short, long)]
+        path: String,
+    },
+    /// Manage the daemon's ruleset
+    Rule {
+        #[arg(short, long)]
+        hash: Option<String>,
+        #[arg(short, long)]
+        action: Option<RuleAction>,
+    }
+}
+
+#[allow(dead_code)]
+fn sender_thread_v2<T: Jsonify>(msg: T) {
+    // create the client socket and send the message
+    let mut client = SantaXpcClient::new(String::from(XPC_SOCKET_PATH));
+    let serial_bytes = msg.jsonify();
+    client.send(serial_bytes.as_bytes()).unwrap();
+
+    // sleep to give the listener a chance to recv the message
+    thread::sleep(Duration::from_millis(50));
+}
 
 fn main() {
+    let args = Cli::parse();
+    let cmd;
+    match &args.command {
+        SubCommands::Status => {
+            let stat = StatusCommand {};
+            cmd = SantaCtlCommand {
+                ctype: CommandTypes::Status,
+                command: stat.jsonify(),
+            };
+        }
+        SubCommands::Fileinfo { path } => {
+            let fileinfo = FileInfoCommand { path: String::from(path)};
+            cmd = SantaCtlCommand {
+                ctype: CommandTypes::FileInfo,
+                command: fileinfo.jsonify(),
+            };
+        }
+        _ => {
+            eprintln!("unimplemented command");
+            return
+        }
+    }
+
     let path = String::from(XPC_CLIENT_PATH);
     let server = SantaXpcServer::new(path, false);
-
     // send the command msg in a thread
     thread::spawn(move || {
-        // create the client socket and send the message
-        let mut client = SantaXpcClient::new(String::from(XPC_SOCKET_PATH));
-        client.send(b"status").unwrap();
-
-        // sleep to give the listener a chance to recv the message
-        thread::sleep(Duration::from_millis(50));
+        sender_thread_v2(cmd);
     });
 
     // sleep to give the sender thread a chance to send the message

--- a/src/santa_kmod/santa_clone.c
+++ b/src/santa_kmod/santa_clone.c
@@ -46,14 +46,14 @@ static DEFINE_SPINLOCK(exec_lock);
  */
 /* callback for handling msg command */
 int gnl_cb_santa_msg_doit(struct sk_buff *sender_skb, struct genl_info *info);
+/* no-op callback for do-hash command */
+int gnl_cb_santa_do_hash_doit(struct sk_buff *sender_skb, struct genl_info *info);
 /* callback for handling hash-done command */
 int gnl_cb_santa_hash_done_doit(struct sk_buff *sender_skb, struct genl_info *info);
 /* callback for handling check-in message */
 int gnl_cb_santa_checkin_doit(struct sk_buff *sender_skb, struct genl_info *info);
 /* error reply callback */
 int gnl_cb_doit_reply_error(struct sk_buff *sender_skb, struct genl_info *info);
-/* callback for handling pid command */
-int gnl_cb_santactl_get_pid_doit(struct sk_buff *sender_skb, struct genl_info *info);
 
 /*
  * ====================
@@ -94,8 +94,8 @@ typedef enum GNL_SANTA_COMMAND {
     GNL_SANTA_C_MSG,
     // CHECK-IN command
     GNL_SANTA_C_MSG_CHECKIN,
-    // GETPID command
-    GNL_SANTA_C_MSG_PID,
+    // DO HASH command (this is sent by the kmod, not handled by it)
+    GNL_SANTA_C_MSG_DO_HASH,
     // HASH DONE command
     GNL_SANTA_C_MSG_HASH_DONE,
     // Reply with error
@@ -155,12 +155,12 @@ struct genl_ops gnl_santa_ops[GNL_SANTA_OPS_LEN] = {
         .done = NULL,
         .validate = 0,
     },
-    // MSG_PID
+    // MSG_DO_HASH (no-op on the kernel side)
     {
-        .cmd = GNL_SANTA_C_MSG_PID,
+        .cmd = GNL_SANTA_C_MSG_DO_HASH,
         .flags = 0,
         .internal_flags = 0,
-        .doit = gnl_cb_santactl_get_pid_doit, // handler
+        .doit = gnl_cb_santa_do_hash_doit, // handler (we reuse the msg-do-it since we have to provide a handler here)
         .dumpit = NULL,
         .start = NULL,
         .done = NULL,
@@ -243,6 +243,15 @@ static struct genl_family gnl_santa_family = {
 
 /**
  * ====================
+ * NO-OP GNL DO_HASH CALLBACK HANDLER IMPLEMENTATION
+ * ====================
+*/
+int gnl_cb_santa_do_hash_doit(struct sk_buff *sender_skb, struct genl_info *info) {
+    return 0;
+}
+
+/**
+ * ====================
  * GNL MSG CALLBACK HANDLER IMPLEMENTATION
  * ====================
 */
@@ -278,67 +287,6 @@ int gnl_cb_santa_msg_doit(struct sk_buff *sender_skb, struct genl_info *info) {
     }
     return 0;
 }
-
-/**
- * ====================
- * GNL GETPID CALLBACK HANDLER IMPLEMENTATION
- * ====================
-*/
-int gnl_cb_santactl_get_pid_doit(struct sk_buff *sender_skb, struct genl_info *info) {
-    struct sk_buff *reply_skb;
-    int rc;
-    void *msg_head;
-    char resp_msg[MAX_PAYLOAD];
-
-    // check we got info in a good state
-    if (info == NULL) {
-        // should never happen
-        pr_err("An error occurred in %s():\n", __func__);
-        return -EINVAL;
-    }
-
-    /* Send a message back */
-    reply_skb = genlmsg_new(NLMSG_GOODSIZE, GFP_KERNEL);
-    if (reply_skb == NULL) {
-        pr_err("An error occurred in %s():\n", __func__);
-        return -ENOMEM;
-    }
-
-    // Create the message headers
-    msg_head = genlmsg_put(
-            reply_skb,          // buffer for netlink message: struct sk_buff *
-            info->snd_portid,   // sending port (not process) id: int
-            0,                  // sequence number: int (might be used by receiver, but not mandatory)
-            &gnl_santa_family,  // struct genl_family *
-            0,                  // flags for Netlink header: int; application specific and not mandatory
-            GNL_SANTA_C_MSG     // The command/operation (u8) from `enum GNL_SANTA_COMMAND`
-    );
-    if (msg_head == NULL) {
-        rc = ENOMEM;
-        pr_err("An error occurred in %s():\n", __func__);
-        return -rc;
-    }
-
-    // Plave the PID in the GNL_SANTA_A_MSG attribute
-    snprintf(resp_msg, sizeof(resp_msg), "%d", agent_pid);
-    rc = nla_put_string(reply_skb, GNL_SANTA_A_MSG, resp_msg);
-    if (rc != 0) {
-        pr_err("An error occurred in %s():\n", __func__);
-        return -rc;
-    }
-
-    // Finalize the message
-    genlmsg_end(reply_skb, msg_head);
-
-    // Send the response
-    rc = genlmsg_reply(reply_skb, info);
-    if (rc != 0) {
-        pr_err("An error occurred in %s():\n", __func__);
-        return -rc;
-    }
-    return 0;
-}
-
 
 /**
  * ====================
@@ -445,6 +393,7 @@ int gnl_cb_santa_hash_done_doit(struct sk_buff *sender_skb, struct genl_info *in
 
 // placeholder for example error reply handler
 int gnl_cb_doit_reply_error(struct sk_buff *sender_skb, struct genl_info *info) {
+    // TODO: we should do something better here
     return -EINVAL;
 }
 
@@ -534,7 +483,7 @@ static int handler_pre_finalize_exec(struct kprobe *p, struct pt_regs *regs)
     snprintf(msg, sizeof(msg), "%d", current->pid);
 
     // send the message to the daemon
-    SantaCommand_t cmd = GNL_SANTA_C_MSG;
+    SantaCommand_t cmd = GNL_SANTA_C_MSG_DO_HASH;
     int res = gnl_santa_send_cmd(cmd, msg);
     if (res != 0) {
         pr_err("[%s]: ERROR %s() ret=%d\n", KMOD_NAME, __func__, res);


### PR DESCRIPTION
## Summary
* add santactl and subcommands: `status`, `fileinfo`, `rule <insert|remove|show>`
* send netlink messages using correct commands
* improve error handling in various parts of the daemon
* update readme

## santactl binary
Add v0 implementation of santactl command and subcommands:

```
santactl is used to interact with the santa-daemon

Usage: santactl <COMMAND>

Commands:
  status    Get status info from the daemon
  fileinfo  Analyze and get info on a target file
  rule      Manage the daemon's ruleset
  help      Print this message or the help of the given subcommand(s)

Options:
  -h, --help  Print help information
```

### Daemon Status

```bash
$ santactl status
{
  "mode": "Monitor",
  "rule_count": 2,
  "cache_count": 4
}
```

### Rule Management

```
Manage the daemon's ruleset

Usage: santactl rule <COMMAND>

Commands:
  show    Show rules
  insert  Insert rules
  delete  Delete rules
  help    Print this message or the help of the given subcommand(s)

Options:
  -h, --help  Print help information
```

### File Info

```
Analyze and get info on a target file

Usage: santactl fileinfo --path <PATH>

Options:
  -p, --path <PATH>
  -h, --help         Print help information
```

```bash
$ santactl fileinfo --path /testbin
{
  "filepath": "/testbin",
  "hash": "ece6694532cee1c661623a6029a2f0563df841e0d2a7034077f7d8d86178ae8a",
  "decision": "Allow",
  "reason": "Unknown"
}
```